### PR TITLE
Fixed dockerfile to use as all in one build tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,35 +5,46 @@
 
 # You can override this `--build-arg BASE_IMAGE=...` to use different
 # version of Rust or OpenSSL.
-ARG BASE_IMAGE=ekidd/rust-musl-builder:latest
+#ARG BASE_IMAGE=ekidd/rust-musl-builder:latest
 
 # Our first FROM statement declares the build environment.
-FROM ${BASE_IMAGE} AS builder
+#FROM ${BASE_IMAGE} AS builder
 
 # Add our source code.
-ADD --chown=rust:rust . ./
-RUN sudo apt-get update
-RUN sudo apt-get install build-essential autoconf automake libtool m4 -y
-RUN sudo apt-get install libopus-dev -y 
-RUN sudo apt-get install ffmpeg -y 
-RUN sudo curl -L https://yt-dl.org/downloads/latest/youtube-dl -o /usr/local/bin/youtube-dl
-RUN sudo chmod a+rx /usr/local/bin/youtube-dl
+FROM ubuntu:18.04
+ 
+RUN apt-get update && apt-get install -y curl
+RUN apt-get install build-essential -y
+ 
+RUN mkdir -p /user/turreta-rust-builder/src
+WORKDIR /user/turreta-rust-builder/src
+ 
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Build our application.
-RUN cargo build --release
-
-# Now, we need to build our _real_ Docker container, copying in `using-diesel`.
-FROM alpine:latest
-RUN apk --no-cache add ca-certificates
-RUN apt update
-RUN apt install build-essential autoconf automake libtool m4 -y
-RUN apt install libopus-dev -y 
-RUN apt install ffmpeg -y 
+#ADD --chown=rust:rust . ./
+RUN apt-get update -y
+RUN apt-get install build-essential autoconf automake libtool m4 -y
+RUN apt-get install libopus-dev -y 
+RUN apt-get install ffmpeg -y 
 RUN curl -L https://yt-dl.org/downloads/latest/youtube-dl -o /usr/local/bin/youtube-dl
 RUN chmod a+rx /usr/local/bin/youtube-dl
 
+# Build our application.
+#RUN cargo build --release
 
-COPY --from=builder \
-    /home/rust/src/target/x86_64-unknown-linux-musl/release/guoboro-rs \
-    /usr/local/bin/
-CMD /usr/local/bin/guoboro-rs
+# Now, we need to build our _real_ Docker container, copying in `using-diesel`.
+#FROM alpine:latest
+#RUN apk --no-cache add ca-certificates
+#RUN apt update
+#RUN apt install build-essential autoconf automake libtool m4 -y
+#RUN apt install libopus-dev -y 
+#RUN apt install ffmpeg -y 
+#RUN curl -L https://yt-dl.org/downloads/latest/youtube-dl -o /usr/local/bin/youtube-dl
+#RUN chmod a+rx /usr/local/bin/youtube-dl
+
+
+#COPY --from=builder \
+#COPY /home/rust/src/target/x86_64-unknown-linux-musl/release/guoboro-rs \
+ #   /usr/local/bin/
+#CMD /usr/local/bin/guoboro-rs


### PR DESCRIPTION
## Overview
okay basically this pr reinvents docker using [this article](https://turreta.com/2020/03/23/rust-and-ubuntu-18-04-docker-image/) so it can be used as a all in one build tool instead of a traditional container

### building 
basically rather than build the exe in the docker container I use the docker container as a wrapper for the DPKG dependencies needed to compile and run this exe.

```bash 
# building the container
docker build -t turreta-rust-builder:1.0 .

# using the container to build the exe
# note that "~/guobaplay" is the local path to the exe
docker run --rm --name rustc -v ~/guobaplay:/user/turreta-rust-builder/src turreta-rust-builder:1.0 cargo build

```

### running 
to run this exe using the docker container the following command can be used. this works similarly to compiling. Note I was unable to fully test this because I do not have a discord key.

```bash 
# this is under the assumption that the above command was used to build this exe
 docker run --rm -v ~/guobaplay:/user/turreta-rust-builder/src turreta-rust-builder:1.0 ./target/debug/guobaplay-rs
```

### Final thoughts 
this isnt a final draft just a working starter, can definitely be cleaned up 

resolves #1 
